### PR TITLE
feat: add SafeAreaView and SafeAreaProvider for improved layout handling

### DIFF
--- a/app/(tabs)/(settings)/components/developers.tsx
+++ b/app/(tabs)/(settings)/components/developers.tsx
@@ -11,6 +11,7 @@ import type { BottomSheetDefaultBackdropProps } from '@gorhom/bottom-sheet/lib/t
 import { ChevronRight, CodeXml, Github, Linkedin } from 'lucide-react-native'
 import { useCallback, useRef } from 'react'
 import { Image, Linking, Pressable, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 export function Developers() {
   const { colorScheme } = useColorScheme()
@@ -80,8 +81,11 @@ export function Developers() {
         }}
         backdropComponent={renderBackdrop}
       >
-        <BottomSheetView className="flex flex-col justify-center gap-4 px-6 py-4 pb-10">
-          <View className="flex flex-col gap-4 w-full">
+        <BottomSheetView className="flex flex-col justify-center gap-4 px-6">
+          <SafeAreaView
+            className="flex flex-col gap-4 w-full"
+            edges={['bottom']}
+          >
             <Text className="text-xl font-semibold">Desenvolvedores</Text>
             <View className="flex flex-col w-full">
               {developers.map(developer => {
@@ -130,7 +134,7 @@ export function Developers() {
                 )
               })}
             </View>
-          </View>
+          </SafeAreaView>
         </BottomSheetView>
       </BottomSheetModal>
     </>

--- a/app/(tabs)/(settings)/components/edit-profile.tsx
+++ b/app/(tabs)/(settings)/components/edit-profile.tsx
@@ -15,6 +15,7 @@ import { ChevronRight } from 'lucide-react-native'
 import { useCallback, useRef, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { Image, Pressable, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { toast } from 'sonner-native'
 import { z } from 'zod'
 
@@ -103,8 +104,11 @@ export function EditProfile() {
         }}
         backdropComponent={renderBackdrop}
       >
-        <BottomSheetView className="flex flex-col items-center justify-center gap-4 px-6 py-4 pb-10">
-          <View className="flex flex-col gap-4 w-full">
+        <BottomSheetView className="flex flex-col items-center justify-center gap-4 px-6">
+          <SafeAreaView
+            className="flex flex-col gap-4 w-full"
+            edges={['bottom']}
+          >
             <Text className="text-xl font-semibold">Editar perfil</Text>
             <View className="flex flex-col w-full">
               <Controller
@@ -153,7 +157,7 @@ export function EditProfile() {
             <Button onPress={handleSubmit(onSubmit)}>
               <Text>Salvar</Text>
             </Button>
-          </View>
+          </SafeAreaView>
         </BottomSheetView>
       </BottomSheetModal>
     </>

--- a/app/(tabs)/(settings)/components/theme-changer.tsx
+++ b/app/(tabs)/(settings)/components/theme-changer.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react-native'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Pressable, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 const themes = [
   {
@@ -110,8 +111,11 @@ export function ThemeChanger() {
         }}
         backdropComponent={renderBackdrop}
       >
-        <BottomSheetView className="flex flex-col justify-center gap-4 px-6 py-4 pb-10">
-          <View className="flex flex-col gap-4 w-full">
+        <BottomSheetView className="flex flex-col justify-center gap-4 px-6">
+          <SafeAreaView
+            className="flex flex-col gap-4 w-full"
+            edges={['bottom']}
+          >
             <Text className="text-xl font-semibold">Selecionar tema</Text>
             <View className="flex flex-col w-full gap-4">
               {themes.map(theme => {
@@ -143,7 +147,7 @@ export function ThemeChanger() {
                 )
               })}
             </View>
-          </View>
+          </SafeAreaView>
         </BottomSheetView>
       </BottomSheetModal>
     </>

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -26,7 +26,6 @@ export default function TabLayout() {
         options={{
           title: 'Início',
           tabBarIcon: ({ color }) => <Home color={color} className="size-5" />,
-          tabBarStyle: { marginBottom: -10 },
         }}
       />
       <Tabs.Screen
@@ -36,7 +35,6 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => (
             <Settings color={color} className="size-5" />
           ),
-          tabBarStyle: { marginBottom: -10 },
         }}
       />
     </Tabs>

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -3,16 +3,21 @@ import { Home, Settings } from 'lucide-react-native'
 
 import Colors from '@/constants/Colors'
 import { useColorScheme } from '@/lib/use-color-scheme'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export default function TabLayout() {
   const { colorScheme } = useColorScheme()
+  const insets = useSafeAreaInsets()
 
   return (
     <Tabs
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
         headerShown: false,
-        tabBarStyle: { height: 60 },
+        tabBarStyle: {
+          paddingBottom: insets.bottom,
+          paddingTop: 8,
+        },
         tabBarItemStyle: { gap: 6 },
       }}
     >
@@ -21,6 +26,7 @@ export default function TabLayout() {
         options={{
           title: 'Início',
           tabBarIcon: ({ color }) => <Home color={color} className="size-5" />,
+          tabBarStyle: { marginBottom: -10 },
         }}
       />
       <Tabs.Screen
@@ -30,6 +36,7 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => (
             <Settings color={color} className="size-5" />
           ),
+          tabBarStyle: { marginBottom: -10 },
         }}
       />
     </Tabs>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,6 +14,7 @@ import { StatusBar } from 'expo-status-bar'
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Platform } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { Toaster } from 'sonner-native'
 
 const LIGHT_THEME: Theme = {
@@ -65,15 +66,17 @@ export default function RootLayout() {
   return (
     <GestureHandlerRootView>
       <ThemeProvider value={isDarkColorScheme ? DARK_THEME : LIGHT_THEME}>
-        <BottomSheetModalProvider>
-          <StatusBar style={isDarkColorScheme ? 'light' : 'dark'} />
-          <Stack screenOptions={{ headerShown: false }} />
-          <Toaster
-            position="top-center"
-            theme={isDarkColorScheme ? 'dark' : 'light'}
-            richColors
-          />
-        </BottomSheetModalProvider>
+        <SafeAreaProvider>
+          <BottomSheetModalProvider>
+            <StatusBar style={isDarkColorScheme ? 'light' : 'dark'} />
+            <Stack screenOptions={{ headerShown: false }} />
+            <Toaster
+              position="top-center"
+              theme={isDarkColorScheme ? 'dark' : 'light'}
+              richColors
+            />
+          </BottomSheetModalProvider>
+        </SafeAreaProvider>
       </ThemeProvider>
     </GestureHandlerRootView>
   )


### PR DESCRIPTION
This pull request introduces the `react-native-safe-area-context` library into the project to ensure proper handling of safe area insets across various components. The changes include wrapping key components with `SafeAreaView` or `SafeAreaProvider` and adjusting styles to account for safe area padding.

### Integration of Safe Area Context:

* `app/_layout.tsx`:
  - Added `SafeAreaProvider` to the root layout to provide safe area context throughout the app. [[1]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57R17) [[2]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57R69) [[3]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57R79)

* `app/(tabs)/_layout.tsx`:
  - Used `useSafeAreaInsets` to dynamically adjust `tabBarStyle` padding for the bottom navigation bar.

### Safe Area Wrapping for Bottom Sheets:

* `app/(tabs)/(settings)/components/developers.tsx`:
  - Replaced `View` with `SafeAreaView` inside the `BottomSheetView` to handle safe area insets for the "Developers" screen. [[1]](diffhunk://#diff-6d2c3378c3f83c511e0708de3e03c121d0e3dc56e23bf68ad66f49964b117415R14) [[2]](diffhunk://#diff-6d2c3378c3f83c511e0708de3e03c121d0e3dc56e23bf68ad66f49964b117415L83-R88) [[3]](diffhunk://#diff-6d2c3378c3f83c511e0708de3e03c121d0e3dc56e23bf68ad66f49964b117415L133-R137)

* `app/(tabs)/(settings)/components/edit-profile.tsx`:
  - Applied `SafeAreaView` to wrap content in the "Edit Profile" bottom sheet for better layout handling. [[1]](diffhunk://#diff-1314dae13261224426dd99b065d0d29fb553d232bb981cefca7c639a1f3ec547R18) [[2]](diffhunk://#diff-1314dae13261224426dd99b065d0d29fb553d232bb981cefca7c639a1f3ec547L106-R111) [[3]](diffhunk://#diff-1314dae13261224426dd99b065d0d29fb553d232bb981cefca7c639a1f3ec547L156-R160)

* `app/(tabs)/(settings)/components/theme-changer.tsx`:
  - Updated the "Theme Changer" bottom sheet to use `SafeAreaView` for consistent spacing around the content. [[1]](diffhunk://#diff-c34ff4e81b63eaea771397061d1337d61e69abe44a82ce5bc17cb71afd4f6586R22) [[2]](diffhunk://#diff-c34ff4e81b63eaea771397061d1337d61e69abe44a82ce5bc17cb71afd4f6586L113-R118) [[3]](diffhunk://#diff-c34ff4e81b63eaea771397061d1337d61e69abe44a82ce5bc17cb71afd4f6586L146-R150)