### PR TITLE
fix(ui): respect device safe areas

### DIFF
--- a/app/(tabs)/(settings)/components/developers.tsx
+++ b/app/(tabs)/(settings)/components/developers.tsx
@@ -11,6 +11,7 @@ import type { BottomSheetDefaultBackdropProps } from '@gorhom/bottom-sheet/lib/t
 import { ChevronRight, CodeXml, Github, Linkedin } from 'lucide-react-native'
 import { useCallback, useRef } from 'react'
 import { Image, Linking, Pressable, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 export function Developers() {
   const { colorScheme } = useColorScheme()
@@ -81,7 +82,10 @@ export function Developers() {
         backdropComponent={renderBackdrop}
       >
         <BottomSheetView className="flex flex-col justify-center gap-4 px-6 py-4 pb-10">
-          <View className="flex flex-col gap-4 w-full">
+          <SafeAreaView
+            className="flex flex-col gap-4 w-full"
+            edges={['bottom']}
+          >
             <Text className="text-xl font-semibold">Desenvolvedores</Text>
             <View className="flex flex-col w-full">
               {developers.map(developer => {
@@ -130,7 +134,7 @@ export function Developers() {
                 )
               })}
             </View>
-          </View>
+          </SafeAreaView>
         </BottomSheetView>
       </BottomSheetModal>
     </>

--- a/app/(tabs)/(settings)/components/edit-profile.tsx
+++ b/app/(tabs)/(settings)/components/edit-profile.tsx
@@ -16,6 +16,7 @@ import { ChevronRight } from 'lucide-react-native'
 import { useCallback, useRef, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { Image, Pressable, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { toast } from 'sonner-native'
 import { z } from 'zod'
 
@@ -113,7 +114,10 @@ export function EditProfile() {
         backdropComponent={renderBackdrop}
       >
         <BottomSheetView className="flex flex-col items-center justify-center gap-4 px-6 py-4 pb-10">
-          <View className="flex flex-col gap-4 w-full">
+          <SafeAreaView
+            className="flex flex-col gap-4 w-full"
+            edges={['bottom']}
+          >
             <Text className="text-xl font-semibold">Editar perfil</Text>
             <View className="flex flex-col w-full">
               <Controller
@@ -162,7 +166,7 @@ export function EditProfile() {
             <Button onPress={handleSubmit(onSubmit)}>
               <Text>Salvar</Text>
             </Button>
-          </View>
+          </SafeAreaView>
         </BottomSheetView>
       </BottomSheetModal>
     </>

--- a/app/(tabs)/(settings)/components/theme-changer.tsx
+++ b/app/(tabs)/(settings)/components/theme-changer.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react-native'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Pressable, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 const themes = [
   {
@@ -111,7 +112,10 @@ export function ThemeChanger() {
         backdropComponent={renderBackdrop}
       >
         <BottomSheetView className="flex flex-col justify-center gap-4 px-6 py-4 pb-10">
-          <View className="flex flex-col gap-4 w-full">
+          <SafeAreaView
+            className="flex flex-col gap-4 w-full"
+            edges={['bottom']}
+          >
             <Text className="text-xl font-semibold">Selecionar tema</Text>
             <View className="flex flex-col w-full gap-4">
               {themes.map(theme => {
@@ -143,7 +147,7 @@ export function ThemeChanger() {
                 )
               })}
             </View>
-          </View>
+          </SafeAreaView>
         </BottomSheetView>
       </BottomSheetModal>
     </>

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -4,9 +4,11 @@ import { Building2, Home, Settings } from 'lucide-react-native'
 import { AuthGuard } from '@/components/auth-guard'
 import Colors from '@/constants/Colors'
 import { useColorScheme } from '@/lib/use-color-scheme'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export default function TabLayout() {
   const { colorScheme } = useColorScheme()
+  const insets = useSafeAreaInsets()
 
   return (
     <AuthGuard>
@@ -14,7 +16,10 @@ export default function TabLayout() {
         screenOptions={{
           tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
           headerShown: false,
-          tabBarStyle: { height: 60 },
+          tabBarStyle: {
+            paddingBottom: insets.bottom,
+            paddingTop: 8,
+          },
           tabBarItemStyle: { gap: 6 },
         }}
       >

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,6 +15,7 @@ import { StatusBar } from 'expo-status-bar'
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Platform } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { Toaster } from 'sonner-native'
 
 const LIGHT_THEME: Theme = {
@@ -67,15 +68,17 @@ export default function RootLayout() {
     <GestureHandlerRootView>
       <ThemeProvider value={isDarkColorScheme ? DARK_THEME : LIGHT_THEME}>
         <AuthProvider>
-          <BottomSheetModalProvider>
-            <StatusBar style={isDarkColorScheme ? 'light' : 'dark'} />
-            <Stack screenOptions={{ headerShown: false }} />
-            <Toaster
-              position="top-center"
-              theme={isDarkColorScheme ? 'dark' : 'light'}
-              richColors
-            />
-          </BottomSheetModalProvider>
+          <SafeAreaProvider>
+            <BottomSheetModalProvider>
+              <StatusBar style={isDarkColorScheme ? 'light' : 'dark'} />
+              <Stack screenOptions={{ headerShown: false }} />
+              <Toaster
+                position="top-center"
+                theme={isDarkColorScheme ? 'dark' : 'light'}
+                richColors
+              />
+            </BottomSheetModalProvider>
+          </SafeAreaProvider>
         </AuthProvider>
       </ThemeProvider>
     </GestureHandlerRootView>


### PR DESCRIPTION
### What & Why
This change introduces safe area handling to ensure the application's UI displays correctly on devices with notches, camera cutouts, or home indicators (e.g., modern iPhones). It wraps the entire application with a `SafeAreaProvider` and applies the necessary insets to prevent UI elements from being obscured.

### How
- The root layout (`app/_layout.tsx`) is wrapped with `SafeAreaProvider` to make insets available throughout the app.
- Safe area insets are applied to the main tab bar layout in `app/(tabs)/_layout.tsx`.
- Several bottom sheet components (`developers.tsx`, `edit-profile.tsx`, `theme-changer.tsx`) have been updated to respect the bottom safe area, preventing content from overlapping with the home indicator.

### Breaking Changes
None.